### PR TITLE
Wait until the documents are indexed

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -109,13 +109,6 @@ async fn build_index() {
         .await
         .unwrap();
 
-    // add the documents
-    let _ = CLIENT
-        .index("clothes")
-        .add_or_update(&clothes, Some("id"))
-        .await
-        .unwrap();
-
     // set displayed attributes
     let _ = CLIENT
         .index("clothes")
@@ -134,6 +127,22 @@ async fn build_index() {
         .set_searchable_attributes(&searchable_attributes)
         .await
         .unwrap();
+
+    // add the documents
+    let result = CLIENT
+        .index("clothes")
+        .add_or_update(&clothes, Some("id"))
+        .await
+        .unwrap()
+        .wait_for_completion(&CLIENT, None, None)
+        .await
+        .unwrap();
+    if result.is_failure() {
+        panic!(
+            "Encountered an error while sending the documents: {:?}",
+            result.unwrap_failure()
+        );
+    }
 }
 
 /// Base search object.


### PR DESCRIPTION
Hey, this PR is doing two things;
1. It's better to index your documents after sending your settings
2. Wait until the documents are indexed before letting the user search for something
3. Bonus: handle the error that could occur while indexing the documents. This is not really needed since we're not doing it for the other settings but I feel like it could be cool to show how to do it